### PR TITLE
Fix workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Give GITHUB_TOKEN permission to push code
     steps:
       - uses: actions/checkout@v3
       - name: Install deps


### PR DESCRIPTION
## Summary
- give GitHub Actions permission to push updates by setting `contents: write`

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684bfca11db0832b9ee1060dd38a2044